### PR TITLE
Allow mail to be embedded into a Jinja2 template

### DIFF
--- a/muttdown/config.py
+++ b/muttdown/config.py
@@ -62,6 +62,8 @@ class Config(object):
         'smtp_password_command': None,
         'smtp_timeout': 10,
         'css_file': None,
+        'template_dir': None,
+        'template': 'muttdown.tmpl',
     }
 
     def __init__(self):

--- a/muttdown/main.py
+++ b/muttdown/main.py
@@ -14,6 +14,8 @@ from email.mime.text import MIMEText
 import markdown
 import pynliner
 
+from jinja2 import Environment,FileSystemLoader,Template
+
 from . import config
 
 
@@ -26,11 +28,20 @@ def convert_one(part, config):
         if '\n-- \n' in text:
             pre_signature, signature = text.split('\n-- \n')
             md = markdown.markdown(pre_signature, output_format="html5")
-            md += '\n<div class="signature" style="font-size: small"><p>-- <br />'
-            md += '<br />'.join(signature.split('\n'))
-            md += '</p></div>'
+            sig = markdown.markdown(signature, output_format="html5")
         else:
             md = markdown.markdown(text)
+            sig = ""
+
+        if config.template_dir and config.template:
+            env = Environment(loader = FileSystemLoader(config.template_dir))
+            tmpl = env.get_template(config.template)
+            md = tmpl.render(body=md, signature=sig)
+        else:
+            md += '\n<div class="signature" style="font-size: small"><p>-- <br />'
+            md += sig
+            md += '</p></div>'
+
         if config.css:
             md = '<style>' + config.css + '</style>' + md
             md = pynliner.fromString(md)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Markdown>=2.0
 PyYAML>=3.0
 pynliner==0.5.2
+jinja2


### PR DESCRIPTION
If template_dir is specified in the config file, muttdown will use
the Jinja2 file named by config.template (default: muttdown.tmpl) in
template_dir to render processed parts.

There are two content variables supplied to the template:
- body
- signature

This can be used to provide a body/table container for the generated
email.

The .md source can remain clean and the HTML email can have styles
attached to the container.
