### PR TITLE
Various improvements to muttdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ If the `remove_sigil` configuration file option is true, the sigil will also be 
 
 The `markdown_extensions` configuration file option can be set to a list of Python markdown extensions that will be enabled (e.g. `[markdown.extensions.extra,markdown.extensions.Admonition]`).
 
+The `utf8` option will assume that the message text is UTF8 and create
+the HTML version appropriately.  This is useful if you receive a lot
+of e-mails (which you want to quote in replies) that include UTF-8
+characters but don't have the encoding set correctly.
+
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The `css_file` should be regular CSS styling blocks; we use [pynliner][] to inli
 
 Muttdown can also send its mail using the native `sendmail` if you have that set up (instead of doing SMTP itself). To do so, just leave the smtp options in the config file blank, set the `sendmail` option to the fully-qualified path to your `sendmail` binary, and run muttdown with the `-s` flag
 
+If the `remove_sigil` configuration file option is true, the sigil will also be removed from the plaintext version of the message part.
+
 Installation
 ------------
 Install muttdown with `pip install muttdown` or by downloading this package and running `python setup.py install`. You will need the [PyYAML][] and [Python-Markdown][] libraries, as specified in `requirements.txt`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 muttdown
 ========
 
-`muttdown` is a sendmail-replacement designed for use with the [mutt][] email client which will transparently compile annotated `text/plain` mail into `text/html` using the [Markdown][] standard.  It will recursively walk the MIME tree and compile any `text/plain` or `text/markdown` part which begins with the sigil "!m" into Markdown, which it will insert alongside the original in a multipart/alternative container.
+`muttdown` is a sendmail-replacement designed for use with the [mutt][] email client which will transparently compile annotated `text/plain` mail into `text/html` using the [Markdown][] standard.  It will recursively walk the MIME tree and compile any `text/plain` or `text/markdown` part which begins with the sigil "!m" into Markdown, which it will insert alongside the original in a multipart/alternative container.  If a part starts with the sigil '!p' it will simply enclose it in &lt;pre&gt; &lt;/pre&gt; tags instead of
+formatting it with markdown.
 
 It's also smart enough not to break `multipart/signed`.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Muttdown can also send its mail using the native `sendmail` if you have that set
 
 If the `remove_sigil` configuration file option is true, the sigil will also be removed from the plaintext version of the message part.
 
+The `markdown_extensions` configuration file option can be set to a list of Python markdown extensions that will be enabled (e.g. `[markdown.extensions.extra,markdown.extensions.Admonition]`).
+
+
 Installation
 ------------
 Install muttdown with `pip install muttdown` or by downloading this package and running `python setup.py install`. You will need the [PyYAML][] and [Python-Markdown][] libraries, as specified in `requirements.txt`.

--- a/muttdown/config.py
+++ b/muttdown/config.py
@@ -64,6 +64,7 @@ class Config(object):
         'css_file': None,
         'sendmail': '/usr/sbin/sendmail',
         'remove_sigil': False,
+        'markdown_extensions' : [],
     }
 
     def __init__(self):

--- a/muttdown/config.py
+++ b/muttdown/config.py
@@ -63,6 +63,7 @@ class Config(object):
         'smtp_timeout': 10,
         'css_file': None,
         'sendmail': '/usr/sbin/sendmail',
+        'remove_sigil': False,
     }
 
     def __init__(self):

--- a/muttdown/config.py
+++ b/muttdown/config.py
@@ -65,6 +65,7 @@ class Config(object):
         'sendmail': '/usr/sbin/sendmail',
         'remove_sigil': False,
         'markdown_extensions' : [],
+        'utf8': False,
     }
 
     def __init__(self):

--- a/muttdown/main.py
+++ b/muttdown/main.py
@@ -170,6 +170,8 @@ def main():
 
         proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, shell=False)
         proc.communicate(rebuilt.as_string())
+        proc.wait()
+        sys.exit(proc.returncode)
 
     else:
         conn = smtp_connection(c)

--- a/muttdown/main.py
+++ b/muttdown/main.py
@@ -53,7 +53,7 @@ def convert_one(part, config):
         else:
             md = converter(text,config)
         if config.css:
-            md = '<style>' + config.css + '</style>' + md
+            md = '<style>\n' + config.css + '</style>\n' + '<body>\n' + md + '\n</body>\n'
             md = pynliner.fromString(md)
         message = MIMEText(md, 'html')
         return message

--- a/muttdown/main.py
+++ b/muttdown/main.py
@@ -27,7 +27,9 @@ def convert_one(part, config):
         text = part.get_payload(None, True)
         if not text.startswith('!m'):
             return None
-        text = re.sub('\s*!m\s*', '', text, re.M)
+        text = re.sub('\s*!m\s*', '', text, count=1, flags=re.M)
+        if config.remove_sigil:
+            part.set_payload(text)
         if '\n-- \n' in text:
             pre_signature, signature = text.split('\n-- \n')
             md = markdown.markdown(pre_signature, output_format="html5")

--- a/muttdown/main.py
+++ b/muttdown/main.py
@@ -35,7 +35,7 @@ def convert_one(part, config):
             part.set_payload(text)
         if '\n-- \n' in text:
             pre_signature, signature = text.split('\n-- \n')
-            md = markdown.markdown(pre_signature, output_format="html5")
+            md = markdown.markdown(pre_signature, config.markdown_extensions, output_format="html5")
             md += '\n<div class="signature" style="font-size: small"><p>-- <br />'
             md += '<br />'.join(signature.split('\n'))
             md += '</p></div>'

--- a/muttdown/main.py
+++ b/muttdown/main.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 from __future__ import print_function
 
 import argparse
@@ -16,11 +17,11 @@ import subprocess
 import markdown
 import pynliner
 
-if 1:
+try:
     from . import config
     from . import __version__
     __name__ = 'muttdown'
-else:
+except ValueError:
     import config
     __version__ = 'testing'
 

--- a/muttdown/main.py
+++ b/muttdown/main.py
@@ -122,7 +122,7 @@ def main():
     parser = argparse.ArgumentParser(version='%s %s' % (__name__, __version__))
     parser.add_argument(
         '-c', '--config_file', default=os.path.expanduser('~/.muttdown.yaml'),
-        type=argparse.FileType('r'), required=True,
+        type=argparse.FileType('r'), required=False,
         help='Path to YAML config file (default %(default)s)'
     )
     parser.add_argument(

--- a/muttdown/main.py
+++ b/muttdown/main.py
@@ -43,7 +43,8 @@ def convert_one(part, config):
             md = pynliner.fromString(md)
         message = MIMEText(md, 'html')
         return message
-    except Exception:
+    except Exception as e:
+        sys.stderr.write('muttdown: '+str(e))
         return None
 
 

--- a/muttdown/main.py
+++ b/muttdown/main.py
@@ -45,6 +45,8 @@ def convert_one(part, config):
         text = re.sub('\s*![pm]\s*', '', text, count=1, flags=re.M)
         if config.remove_sigil:
             part.set_payload(text)
+        if config.utf8:
+            text = unicode(text,'utf8')
         if '\n-- \n' in text:
             pre_signature, signature = text.split('\n-- \n')
             md = converter(pre_signature,config)
@@ -56,7 +58,10 @@ def convert_one(part, config):
         if config.css:
             md = '<style>\n' + config.css + '</style>\n' + '<body>\n' + md + '\n</body>\n'
             md = pynliner.fromString(md)
-        message = MIMEText(md, 'html')
+        if config.utf8:
+            message = MIMEText(md.encode('utf-8'), 'html', _charset='utf-8')
+        else:
+            message = MIMEText(md, 'html')
         return message
     except Exception as e:
         sys.stderr.write('muttdown: '+str(e))

--- a/muttdown/main.py
+++ b/muttdown/main.py
@@ -16,10 +16,13 @@ import subprocess
 import markdown
 import pynliner
 
-from . import config
-from . import __version__
-
-__name__ = 'muttdown'
+if 1:
+    from . import config
+    from . import __version__
+    __name__ = 'muttdown'
+else:
+    import config
+    __version__ = 'testing'
 
 
 def convert_one(part, config):


### PR DESCRIPTION
- Only remove the first occurance of the sigil, and add option to also remove it from plaintext version.

- Allow main.py to run without installing (useful during development).

-  Add '!p' sigil that just encloses everything in pre /pre tags.  Useful when you want to send ascii diagrams to HTML users.

- Allow user to specify markdown extensions.

- Return failure if sendmail subprocess fails.

- Add 'utf8' option to tell muttdown to treat text/plain message as UTF8 when converting.

