### PR TITLE
Split Config.sendmail on spaces for passing to Popen

### DIFF
--- a/muttdown/main.py
+++ b/muttdown/main.py
@@ -159,7 +159,7 @@ def main():
     if args.print_message:
         print(rebuilt.as_string())
     elif args.sendmail_passthru:
-        cmd = c.sendmail.split(' ') + ['-f', args.envelope_from] + args.addresses
+        cmd = c.sendmail.split() + ['-f', args.envelope_from] + args.addresses
 
         proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, shell=False)
         proc.communicate(rebuilt.as_string())

--- a/muttdown/main.py
+++ b/muttdown/main.py
@@ -159,7 +159,7 @@ def main():
     if args.print_message:
         print(rebuilt.as_string())
     elif args.sendmail_passthru:
-        cmd = [c.sendmail, '-f', args.envelope_from] + args.addresses
+        cmd = c.sendmail.split(' ') + ['-f', args.envelope_from] + args.addresses
 
         proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, shell=False)
         proc.communicate(rebuilt.as_string())


### PR DESCRIPTION
Hey, great to see some activity again!  It got me started hacking again.

For some reason, Popen started giving me errors if my Config.sendmail was a command with arguments like, `msmtp -a nottwo`.    It used to work.
