### PR TITLE
Treat signature as markdown, but process w/ nl2br extension

### DIFF
--- a/muttdown/main.py
+++ b/muttdown/main.py
@@ -34,8 +34,11 @@ def convert_one(part, config):
         if '\n-- \n' in text:
             pre_signature, signature = text.split('\n-- \n')
             md = markdown.markdown(pre_signature, output_format="html5")
+            sig = markdown.markdown(signature, output_format="html5",
+                    extensions=["markdown.extensions.nl2br"])
+
             md += '\n<div class="signature" style="font-size: small"><p>-- <br />'
-            md += '<br />'.join(signature.split('\n'))
+            md += '<br />' + sig
             md += '</p></div>'
         else:
             md = markdown.markdown(text)


### PR DESCRIPTION
Hi,

I guess the template idea from #2 wasn't too popular. How about just allowing the signature be .md?

My workplace has standardized on a rich signature that I have complied with by treating the sig as markdown and then adding appropriate styles:

```markdown
**First Lastname**
Title
[800-555-0123](tel:800-555-0123)
_[company](company-url)_
```

Rather than splitting the signature by newlines & joining with \<br>s, I process the signature with the nl2br extension so that text/plain format=flowed  & md->HTML versions of the email are presented properly.