### PR TITLE
Move to pandoc for markdown and premailer for CSS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,9 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     install_requires=[
-        'Markdown>=2.0',
         'PyYAML>=3.0',
-        'pynliner==0.8.0',
+        'pypandoc',
+        'premailer',
         'six',
     ],
     entry_points={


### PR DESCRIPTION
This is a proof of principle, but fully functional pull request. For my purposes, using the pandoc variant of markdown just makes the most sense. I also think it is the most robust and featureful so require it as an option in any markdown based tool I use. It was pretty easy to implement that in muttdown, leveraging other packages already available. `pyliner` also does not seem all that well maintained so I opted for `premailer` to perform the CSS in-lining instead, which seems reasonable since it is well tested and designed for this very purpose. 

I currently have this version of muttdown set up as a filter on my local Postfix install and it works great. The last detail at this stage I would like to see changed is to remove the `!m` sigil from the `text/plain` part. That is not currently written back into the multipart object.

So, I am going to continue down this path regardless of whether or not you would like to merge, but if this all seems in line with what you wanted to do then I am happy to have that happen in muttdown's birth repo (this one). 